### PR TITLE
Add support for `apps` folder structure

### DIFF
--- a/bin/mzbench
+++ b/bin/mzbench
@@ -359,7 +359,7 @@ def run_or_validate(script, env, validate):
                 print ("WARNING: make didn't produce worker beam files")
 
     pa = []
-    for p in glob.glob(os.getcwd() + "/deps/*/ebin"):
+    for p in glob.glob(os.getcwd() + "/deps/*/ebin") + glob.glob(os.getcwd() + "/apps/*/ebin"):
         pa += ["--pa", p]
     cmd = [os.path.join(escript_path, escript_name), script, '--pa', os.getcwd() + "/ebin"] + pa
 

--- a/node/apps/mzbench/src/mzb_app.erl
+++ b/node/apps/mzbench/src/mzb_app.erl
@@ -9,7 +9,8 @@ start(_, _) ->
 
     CodeWildcards =
         [filename:join([D, "*", "ebin"])              || D <- WorkerDirs] ++
-        [filename:join([D, "*", "deps", "*", "ebin"]) || D <- WorkerDirs],
+        [filename:join([D, "*", "deps", "*", "ebin"]) || D <- WorkerDirs] ++
+        [filename:join([D, "*", "apps", "*", "ebin"]) || D <- WorkerDirs],
 
     CodePaths = [File || WC <- CodeWildcards, File <- mzb_file:wildcard(WC)],
 


### PR DESCRIPTION
Now we can have a worker project structure similar to this:
```
apps/
  app1/
    ebin/
    src/
  app2/
    ebin/
    src/
rebar
rebar.config
Makefile
sys.config
```
... and being able to run `mzbench run` or `mzbench run_local` without complaining that the worker module is not being found.