### PR TITLE
Fix tcpkali latency metrics name

### DIFF
--- a/workers/tcpkali/src/tcpkali_worker.erl
+++ b/workers/tcpkali/src/tcpkali_worker.erl
@@ -40,12 +40,12 @@ metrics() ->
                                   {"tcpkali.traffic.bitrate.out", gauge}]}},
             {graph, #{title => "Latency",
                       units => "ms",
-                      metrics => [{"latency.mean", gauge},
-                                  {"latency.50", gauge},
-                                  {"latency.95", gauge},
-                                  {"latency.99", gauge},
-                                  {"latency.99.5", gauge},
-                                  {"latency.max", gauge}]}},
+                      metrics => [{"tcpkali.latency.message.mean", gauge},
+                                  {"tcpkali.latency.message.50", gauge},
+                                  {"tcpkali.latency.message.95", gauge},
+                                  {"tcpkali.latency.message.99", gauge},
+                                  {"tcpkali.latency.message.99.5", gauge},
+                                  {"tcpkali.latency.message.max", gauge}]}},
             {graph, #{title => "Traffic data",
                       units => "N",
                       metrics => [{"tcpkali.traffic.data", counter},
@@ -57,7 +57,8 @@ metrics() ->
     ].
 
 start(#state{executable = Exec} = State, _Meta, Options) ->
-    Command = Exec ++ lists:foldr(fun({url, Url}, A) -> A ++ " \"" ++ Url ++ "\"";
+    Command = Exec ++ lists:foldr(fun({raw, Raw}, A) -> A ++ " " ++ Raw;
+                        ({url, Url}, A) -> A ++ " \"" ++ Url ++ "\"";
                         ({Opt, Val}, A) ->
                             L = string:join(string:tokens(atom_to_list(Opt), "_"), "-"),
                             Val2 = prepare_val(Val),


### PR DESCRIPTION
Tcpkali latency metrics names were changed.
And also I would like to forward raw string with complex arguments to tcpkali.
Example:
start(raw = "--statsd -T 60s -r10000 --latency-marker 'HTTP' -em 'GET / HTTP/1.1\r\nHost: google.com\r\n\r\n' google.com:80")