### PR TITLE
add multiline resource file

### DIFF
--- a/common_apps/mzbench_language/src/mzbl_script.erl
+++ b/common_apps/mzbench_language/src/mzbl_script.erl
@@ -240,7 +240,9 @@ interpret_defaults(DefaultsList, Env) ->
              (string() | binary(), binary) -> binary();
              (string() | binary(), text) -> string();
              (string() | binary(), json) -> list() | map();
-             (string() | binary(), tsv) -> [string()].
+             (string() | binary(), lines) -> [string()];
+             (string() | binary(), tsv) -> [binary()].
+convert(X, lines) when is_binary(X) -> binary:split(X, <<"\n">>);
 convert(X, binary) when is_binary(X) -> X;
 convert(X, binary) -> list_to_binary(X);
 convert(X, text) when is_binary(X) -> binary_to_list(X);


### PR DESCRIPTION
To be used with a resource file like this:
```#!benchDL
defaults("output" = "./randomLogLines.log")
include_resource(names, "somelog.log", lines)
pool(size = 3,
    worker_type = qq_worker):
    loop(time = 10 sec,
        rate = 300 rps):
        append(var("output"), choose(resource(names))) # print a random line from the file
```