### PR TITLE
Multiline resource

### DIFF
--- a/common_apps/mzbench_language/src/mzbl_script.erl
+++ b/common_apps/mzbench_language/src/mzbl_script.erl
@@ -240,7 +240,9 @@ interpret_defaults(DefaultsList, Env) ->
              (string() | binary(), binary) -> binary();
              (string() | binary(), text) -> string();
              (string() | binary(), json) -> list() | map();
-             (string() | binary(), tsv) -> [string()].
+             (string() | binary(), lines) -> [string()];
+             (string() | binary(), tsv) -> [binary()].
+convert(X, lines) when is_binary(X) -> binary:split(X, <<"\n">>);
 convert(X, binary) when is_binary(X) -> X;
 convert(X, binary) -> list_to_binary(X);
 convert(X, text) when is_binary(X) -> binary_to_list(X);

--- a/common_apps/mzbench_language/src/mzbl_script.erl
+++ b/common_apps/mzbench_language/src/mzbl_script.erl
@@ -221,10 +221,7 @@ import_resource(Env, File, Type) ->
                         end
                 end
         end,
-        case Type of
-            lines ->  convert(string2lines(erlang:binary_to_list(Content), []), Type) ;
-            _ -> convert(Content, Type)
-        end
+        convert(Content, Type)
     catch
         _:Reason ->
             lager:error("Resource ~p(~p) import error: ~p", [File, Type, Reason]),
@@ -247,9 +244,9 @@ interpret_defaults(DefaultsList, Env) ->
              (string() | binary(), binary) -> binary();
              (string() | binary(), text) -> string();
              (string() | binary(), json) -> list() | map();
-             (string() | binary(), lines) -> [binary()];
+             ([binary()], lines) -> [binary()];
              (string() | binary(), tsv) -> [binary()].
-convert(X, lines) -> X;
+convert(X, lines) ->  string2lines(erlang:binary_to_list(X), []);
 convert(X, binary) when is_binary(X) -> X;
 convert(X, binary) -> list_to_binary(X);
 convert(X, text) when is_binary(X) -> binary_to_list(X);


### PR DESCRIPTION
Give it a file of lines as a resource, which comes in as a [binary()].  Can be used like this:

```
#!benchDL
defaults("output" = "./qq.out")
include_resource(names, "somelog.log", lines)
pool(size = 2,
    worker_type = qq_worker):
    loop(time = 10 sec,
        rate = 100 rps):
        append(var("output"), choose(resource(names))) # print a random name from the file
```