### PR TITLE
Lines resource

### DIFF
--- a/common_apps/mzbench_language/src/mzbl_script.erl
+++ b/common_apps/mzbench_language/src/mzbl_script.erl
@@ -193,10 +193,6 @@ extract_info(Script, Env) ->
     Script3 = mzbl_ast:map_meta(fun (Meta, Op) -> [{function, Op}|Meta] end, Script2),
     {Script3, Env2, Asserts}.
 
-string2lines("\n" ++ Str, Acc) -> [lists:reverse([$\n|Acc]) | string2lines(Str,[])];
-string2lines([H|T], Acc)       -> string2lines(T, [H|Acc]);
-string2lines([], Acc)          -> [lists:reverse(Acc)].
-
 import_resource(Env, File, Type) ->
     try
         Content = case re:run(File, "^https?://", [{capture, first}, caseless]) of
@@ -245,9 +241,10 @@ interpret_defaults(DefaultsList, Env) ->
              (string() | binary(), binary) -> binary();
              (string() | binary(), text) -> string();
              (string() | binary(), json) -> list() | map();
-             ([binary()], lines) -> [binary()];
+             (string() | binary(), lines) -> [string()];
              (string() | binary(), tsv) -> [binary()].
-convert(X, lines) ->  string2lines(erlang:binary_to_list(X), []);
+convert(X, lines) when is_binary(X) -> convert(binary_to_list(X), lines);
+convert(X, lines) when is_list(X) ->  string:tokens(X, "\n");
 convert(X, binary) when is_binary(X) -> X;
 convert(X, binary) -> list_to_binary(X);
 convert(X, text) when is_binary(X) -> binary_to_list(X);

--- a/common_apps/mzbench_language/src/mzbl_script.erl
+++ b/common_apps/mzbench_language/src/mzbl_script.erl
@@ -3,6 +3,7 @@
 -export([parse/1,
          hostname/1,
          add_indents/1,
+         convert/2,
          get_real_script_name/1,
          read/1,
          read_from_string/1,

--- a/common_apps/mzbench_language/src/mzbl_script.erl
+++ b/common_apps/mzbench_language/src/mzbl_script.erl
@@ -240,7 +240,9 @@ interpret_defaults(DefaultsList, Env) ->
              (string() | binary(), binary) -> binary();
              (string() | binary(), text) -> string();
              (string() | binary(), json) -> list() | map();
-             (string() | binary(), tsv) -> [string()].
+             (string() | binary(), lines) -> [string()];
+             (string() | binary(), tsv) -> [binary()].
+convert(X, lines) when is_binary(X) -> binary:split(X, <<"\n">>);
 convert(X, binary) when is_binary(X) -> X;
 convert(X, binary) -> list_to_binary(X);
 convert(X, text) when is_binary(X) -> binary_to_list(X);

--- a/common_apps/mzbench_language/src/mzbl_script.erl
+++ b/common_apps/mzbench_language/src/mzbl_script.erl
@@ -221,10 +221,7 @@ import_resource(Env, File, Type) ->
                         end
                 end
         end,
-        case Type of
-            lines ->  convert(string2lines(erlang:binary_to_list(Content), []), Type) ;
-            _ -> convert(Content, Type)
-        end
+        convert(Content, Type)
     catch
         _:Reason ->
             lager:error("Resource ~p(~p) import error: ~p", [File, Type, Reason]),
@@ -247,9 +244,9 @@ interpret_defaults(DefaultsList, Env) ->
              (string() | binary(), binary) -> binary();
              (string() | binary(), text) -> string();
              (string() | binary(), json) -> list() | map();
-             (string() | binary(), lines) -> [binary()];
+             ([binary()], lines) -> [binary()];
              (string() | binary(), tsv) -> [binary()].
-convert(X, lines) -> X;
+convert(X, lines) ->  string2lines(erlang:binary_to_list(X), []);
 convert(X, binary) when is_binary(X) -> X;
 convert(X, binary) -> list_to_binary(X);
 convert(X, text) when is_binary(X) -> binary_to_list(X);

--- a/common_apps/mzbench_language/test/mzbl_script_tests.erl
+++ b/common_apps/mzbench_language/test/mzbl_script_tests.erl
@@ -174,4 +174,4 @@ install_specs_check(ExpectedInstallSpecs, Script) ->
     ?assertEqual(ExpectedInstallSpecs, mzbl_script:extract_install_specs(AST, [])).
 
 convert_lines_test() ->
-    ?assertEqual(["A\n","B\n","C"], mzbl_script:convert(<<"A\nB\nC">>, lines)).
+    ?assertEqual(["A","B","C"], mzbl_script:convert(<<"A\nB\nC">>, lines)).

--- a/common_apps/mzbench_language/test/mzbl_script_tests.erl
+++ b/common_apps/mzbench_language/test/mzbl_script_tests.erl
@@ -172,3 +172,6 @@ extract_while_metrics_test() ->
 install_specs_check(ExpectedInstallSpecs, Script) ->
     AST = mzbl_script:read_from_string(Script),
     ?assertEqual(ExpectedInstallSpecs, mzbl_script:extract_install_specs(AST, [])).
+
+convert_lines_test() ->
+    ?assertEqual(["A\n","B\n","C"], mzbl_script:convert(<<"A\nB\nC">>, lines)).


### PR DESCRIPTION
Give it a file of lines as a resource, which comes in as a [binary()]. Can be used like this:

```
#!benchDL
defaults("output" = "./qq.out")
include_resource(names, "somelog.log", lines)
pool(size = 2,
    worker_type = qq_worker):
    loop(time = 10 sec,
        rate = 100 rps):
        append(var("output"), choose(resource(names))) # print a random name from the file
```